### PR TITLE
Fix for reading TXT Records.

### DIFF
--- a/src/Ubiety.Dns.Core/Common/Extensions/EnumExtensions.cs
+++ b/src/Ubiety.Dns.Core/Common/Extensions/EnumExtensions.cs
@@ -31,17 +31,11 @@ namespace Ubiety.Dns.Core.Common.Extensions
         /// </summary>
         /// <param name="type">Type of record to get.</param>
         /// <param name="reader">Resource reader to create record with.</param>
-        /// <param name="length">Length of the record.</param>
         /// <returns>A <see cref="Record"/> instance for the given type.</returns>
-        public static Record GetRecord(this RecordType type, RecordReader reader, int length = 0)
+        public static Record GetRecord(this RecordType type, RecordReader reader)
         {
             var fieldInfo = type.GetType().GetField(type.ToString());
             var recordAttr = fieldInfo.GetCustomAttribute<RecordAttribute>();
-
-            if (type == RecordType.TXT)
-            {
-                return (Record)Activator.CreateInstance(recordAttr.RecordType, reader, length);
-            }
 
             return (Record)Activator.CreateInstance(recordAttr.RecordType, reader);
         }

--- a/src/Ubiety.Dns.Core/Records/RecordTxt.cs
+++ b/src/Ubiety.Dns.Core/Records/RecordTxt.cs
@@ -45,16 +45,13 @@ namespace Ubiety.Dns.Core.Records
         ///     Initializes a new instance of the <see cref="RecordTxt" /> class.
         /// </summary>
         /// <param name="reader"><see cref="RecordReader" /> for the record data.</param>
-        /// <param name="length">Record length.</param>
-        public RecordTxt(RecordReader reader, int length)
+        public RecordTxt(RecordReader reader)
             : base(reader)
         {
-            var position = Reader.Position;
-            Text = new List<string>();
-            while ((Reader.Position - position) < length)
+            Text = new List<string>
             {
-                Text.Add(Reader.ReadString());
-            }
+                Reader.ReadString()
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
Reading the Text field of a TXT Record did not work due to length property in the constructor of the RecordTxt.cs class always being 0. We can simply use the RecordReader.ReadString function as this takes into account the TXT Length.