### PR TITLE
Test pull requests in a workflow that does not publish

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,21 +9,20 @@
 #
 #     - To trigger manual generation invoke:
 #
-#         nuke --generate-configuration GitHubActions_continuous --host GitHubActions
+#         nuke --generate-configuration GitHubActions_pr --host GitHubActions
 #
 # </auto-generated>
 # ------------------------------------------------------------------------------
 
-name: continuous
+name: pr
 
 on:
-  push:
-    branches-ignore:
-      - 'release/*'
+  pull_request:
+    branches:
+      - develop
       - main
 
 permissions:
-  packages: write
   contents: read
 
 jobs:
@@ -41,10 +40,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Run: Test, Publish'
-        run: ./build.cmd Test Publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Run: Test'
+        run: ./build.cmd Test
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
@@ -59,10 +56,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Run: Test, Publish'
-        run: ./build.cmd Test Publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Run: Test'
+        run: ./build.cmd Test
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -77,7 +72,5 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Run: Test, Publish'
-        run: ./build.cmd Test Publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Run: Test'
+        run: ./build.cmd Test

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -45,12 +45,24 @@ namespace _build;
     GitHubActionsImage.MacOsLatest,
     GitHubActionsImage.UbuntuLatest,
     OnPushBranchesIgnore = [ReleaseBranchPrefix, MasterBranch],
-    OnPullRequestBranches = [DevelopBranch],
     PublishArtifacts = false,
     InvokedTargets = [nameof(Test), nameof(Publish)],
     EnableGitHubToken = true,
     ReadPermissions = [GitHubActionsPermissions.Contents],
     WritePermissions = [GitHubActionsPermissions.Packages],
+    FetchDepth = 0)]
+// Pull requests test only. A pull_request event checks out the detached merge ref, so there is no
+// branch for GitRepository to resolve, Beta is false whatever the source branch is called, and
+// Publish would demand a nuget.org key this workflow has no reason to hold. Keeping Publish out
+// of the pull request build lets it keep a hard Requires for the release path.
+[GitHubActions("pr",
+    GitHubActionsImage.WindowsLatest,
+    GitHubActionsImage.MacOsLatest,
+    GitHubActionsImage.UbuntuLatest,
+    OnPullRequestBranches = [DevelopBranch, MasterBranch],
+    PublishArtifacts = false,
+    InvokedTargets = [nameof(Test)],
+    ReadPermissions = [GitHubActionsPermissions.Contents],
     FetchDepth = 0)]
 // Releases go to nuget.org via trusted publishing, which needs id-token to exchange the OIDC
 // token for a short-lived key. A single image keeps the push from racing itself.


### PR DESCRIPTION
Every pull request into `develop` fails CI, and has done regardless of the change proposed.

A `pull_request` event checks out the detached merge ref (`refs/pull/N/merge`), so `GitRepository` has no branch name to resolve. `Beta` is therefore false no matter what the source branch is called, and `Publish` fails its `Requires` asking for a nuget.org key that the `continuous` workflow has no reason to hold:

```
Target 'Publish' requires '(Not(value(_build.Build).NuGetKey.IsNullOrEmpty()) OrElse value(_build.Build).Beta)'
```

Pull requests now run `Test` in their own workflow, and `continuous` keeps the push trigger it already had.

`Publish` keeps its hard `Requires` rather than being softened to `OnlyWhenStatic`, so a release that reaches it without a key still fails loudly instead of quietly shipping nothing.

Found while opening a PR in Ubiety.Scram.Core, which shares this build; the equivalent change is [ubiety/Ubiety.Scram.Core#10](https://github.com/ubiety/Ubiety.Scram.Core/pull/10). 189 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)